### PR TITLE
Set unpaid WesternBid status during order validation

### DIFF
--- a/controllers/front/external.php
+++ b/controllers/front/external.php
@@ -104,7 +104,11 @@ class Westernbid_Starter_StripeExternalModuleFrontController extends ModuleFront
 
         // Параметри замовлення
         $payment_method = 'Western Bid Stripe';
-        $order_status_id = Configuration::get('PS_OS_PREPARATION'); // Ідентифікатор статусу замовлення
+        $order_status_id = (int) Configuration::get(Westernbid_Starter_Stripe::STARTER_WB_STRIPE_WAITING_PAYMENT_STATE);
+
+        if (!$order_status_id) {
+            $order_status_id = (int) Configuration::get('PS_OS_PREPARATION');
+        }
         $currency_id = (int)$currency->id;
 
         // Виклик validateOrder для підтвердження замовлення


### PR DESCRIPTION
## Summary
- initialize external payment orders with the module-specific waiting payment state
- fall back to the default preparation status if the custom state is unavailable

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68cbc5851e20832386fd2fa0aff0ccc8