### PR TITLE
Add admin settings for download blocking and auto cancel

### DIFF
--- a/controllers/admin/AdminConfigurePaymentWesternbidStripeController.php
+++ b/controllers/admin/AdminConfigurePaymentWesternbidStripeController.php
@@ -41,6 +41,13 @@ class AdminConfigurePaymentWesternbidStripeController extends ModuleAdminControl
                         'cast' => 'intval',
                         'required' => false,
                     ],
+                    Westernbid_Starter_Stripe::STARTER_WB_STRIPE_BLOCK_DOWNLOADS => [
+                        'type' => 'bool',
+                        'title' => $this->l('Block downloads until payment is confirmed'),
+                        'validation' => 'isBool',
+                        'cast' => 'intval',
+                        'required' => false,
+                    ],
                     Westernbid_Starter_Stripe::STARTER_WB_STRIPE_LOGIN => [
                         'type' => 'text',
                         'title' => $this->l('Western bid LOGIN'),
@@ -51,6 +58,14 @@ class AdminConfigurePaymentWesternbidStripeController extends ModuleAdminControl
                         'type' => 'text',
                         'title' => $this->l('Western bid SECRET KEY'),
                         'required' => true,
+                    ],
+                    Westernbid_Starter_Stripe::STARTER_WB_STRIPE_AUTO_CANCEL_HOURS => [
+                        'type' => 'text',
+                        'title' => $this->l('Auto cancel unpaid orders after N hours'),
+                        'validation' => 'isUnsignedInt',
+                        'cast' => 'intval',
+                        'required' => false,
+                        'desc' => $this->l('Set 0 to disable automatic cancellation'),
                     ],
 
                 ],

--- a/controllers/front/external.php
+++ b/controllers/front/external.php
@@ -104,10 +104,20 @@ class Westernbid_Starter_StripeExternalModuleFrontController extends ModuleFront
 
         // Параметри замовлення
         $payment_method = 'Western Bid Stripe';
-        $order_status_id = (int) Configuration::get(Westernbid_Starter_Stripe::STARTER_WB_STRIPE_WAITING_PAYMENT_STATE);
+        $blockDownloads = (bool) Configuration::get(Westernbid_Starter_Stripe::STARTER_WB_STRIPE_BLOCK_DOWNLOADS);
 
-        if (!$order_status_id) {
-            $order_status_id = (int) Configuration::get('PS_OS_PREPARATION');
+        if ($blockDownloads) {
+            $order_status_id = (int) Configuration::get(Westernbid_Starter_Stripe::STARTER_WB_STRIPE_WAITING_PAYMENT_STATE);
+
+            if (!$order_status_id) {
+                $order_status_id = (int) Configuration::get('PS_OS_PREPARATION');
+            }
+        } else {
+            $order_status_id = (int) Configuration::get('PS_OS_PAYMENT');
+
+            if (!$order_status_id) {
+                $order_status_id = (int) Configuration::get('PS_OS_PREPARATION');
+            }
         }
         $currency_id = (int)$currency->id;
 

--- a/westernbid_starter_stripe.php
+++ b/westernbid_starter_stripe.php
@@ -31,12 +31,15 @@ class Westernbid_Starter_Stripe extends PaymentModule
 
     const STARTER_WB_STRIPE_LOGIN = 'PAYMENT_STARTER_WB_STRIPE_LOGIN';
     const STARTER_WB_STRIPE_SECRETKEY = 'PAYMENT_STARTER_WB_STRIPE_SECRETKEY';
+    const STARTER_WB_STRIPE_BLOCK_DOWNLOADS = 'STARTER_WB_STRIPE_BLOCK_DOWNLOADS';
+    const STARTER_WB_STRIPE_AUTO_CANCEL_HOURS = 'STARTER_WB_STRIPE_AUTO_CANCEL_HOURS';
 
     const MODULE_ADMIN_CONTROLLER = 'AdminConfigurePaymentWesternbidStripe';
     const STARTER_WB_STRIPE_WAITING_PAYMENT_STATE = 'STARTER_WB_STRIPE_WAITING_PAYMENT_STATE';
     const STARTER_WB_STRIPE_WAITING_PAYMENT_NAME = 'Ожидание оплаты WesternBid';
     const HOOKS = [
         'paymentOptions',
+        'actionFrontControllerAfterInit',
     ];
 
     public function __construct()
@@ -148,7 +151,9 @@ class Westernbid_Starter_Stripe extends PaymentModule
      */
     private function installConfiguration()
     {
-        return (bool) Configuration::updateGlobalValue(static::STARTER_WB_STRIPE_ENABLED, '1');
+        return (bool) Configuration::updateGlobalValue(static::STARTER_WB_STRIPE_ENABLED, '1')
+            && (bool) Configuration::updateGlobalValue(static::STARTER_WB_STRIPE_BLOCK_DOWNLOADS, '1')
+            && (bool) Configuration::updateGlobalValue(static::STARTER_WB_STRIPE_AUTO_CANCEL_HOURS, '24');
     }
 
     /**
@@ -158,7 +163,9 @@ class Westernbid_Starter_Stripe extends PaymentModule
      */
     private function uninstallConfiguration()
     {
-        return (bool) Configuration::deleteByName(static::STARTER_WB_STRIPE_ENABLED);
+        return (bool) Configuration::deleteByName(static::STARTER_WB_STRIPE_ENABLED)
+            && (bool) Configuration::deleteByName(static::STARTER_WB_STRIPE_BLOCK_DOWNLOADS)
+            && (bool) Configuration::deleteByName(static::STARTER_WB_STRIPE_AUTO_CANCEL_HOURS);
     }
 
     /**
@@ -318,5 +325,63 @@ class Westernbid_Starter_Stripe extends PaymentModule
         }
 
         return false;
+    }
+
+    /**
+     * Cancel unpaid orders that expired according to configuration
+     */
+    public function hookActionFrontControllerAfterInit()
+    {
+        if (!Configuration::get(static::STARTER_WB_STRIPE_BLOCK_DOWNLOADS)) {
+            return;
+        }
+
+        $autoCancelHours = (int) Configuration::get(static::STARTER_WB_STRIPE_AUTO_CANCEL_HOURS);
+
+        if ($autoCancelHours <= 0) {
+            return;
+        }
+
+        $waitingState = (int) Configuration::get(static::STARTER_WB_STRIPE_WAITING_PAYMENT_STATE);
+
+        if ($waitingState <= 0) {
+            return;
+        }
+
+        $deadline = date('Y-m-d H:i:s', time() - ($autoCancelHours * 3600));
+
+        $query = new DbQuery();
+        $query->select('o.id_order');
+        $query->from('orders', 'o');
+        $query->where('o.current_state = ' . (int) $waitingState);
+        $query->where("o.module = '" . pSQL($this->name) . "'");
+        $query->where("o.date_add < '" . pSQL($deadline) . "'");
+
+        $orders = Db::getInstance()->executeS($query);
+
+        if (empty($orders)) {
+            return;
+        }
+
+        $cancelState = (int) Configuration::get('PS_OS_CANCELED');
+
+        foreach ($orders as $orderData) {
+            $orderId = (int) $orderData['id_order'];
+
+            if ($orderId <= 0) {
+                continue;
+            }
+
+            $order = new Order($orderId);
+
+            if (!Validate::isLoadedObject($order) || (int) $order->current_state !== $waitingState) {
+                continue;
+            }
+
+            $orderHistory = new OrderHistory();
+            $orderHistory->id_order = $orderId;
+            $orderHistory->changeIdOrderState($cancelState, $orderId);
+            $orderHistory->addWithemail();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add configuration flags for download blocking and auto cancellation defaults during install
- expose new checkbox and numeric field in the module configuration form
- honor the settings when validating orders and automatically cancel stale unpaid orders

## Testing
- php -l westernbid_starter_stripe.php
- php -l controllers/front/external.php
- php -l controllers/admin/AdminConfigurePaymentWesternbidStripeController.php

------
https://chatgpt.com/codex/tasks/task_b_68cbca28cf588323823947caacdf0af4