### PR TITLE
Add cron endpoint for automatic cancellation of unpaid orders

### DIFF
--- a/controllers/admin/AdminConfigurePaymentWesternbidStripeController.php
+++ b/controllers/admin/AdminConfigurePaymentWesternbidStripeController.php
@@ -67,6 +67,12 @@ class AdminConfigurePaymentWesternbidStripeController extends ModuleAdminControl
                         'required' => false,
                         'desc' => $this->l('Set 0 to disable automatic cancellation'),
                     ],
+                    Westernbid_Starter_Stripe::STARTER_WB_STRIPE_CRON_TOKEN => [
+                        'type' => 'text',
+                        'title' => $this->l('Cron security token'),
+                        'required' => true,
+                        'desc' => $this->l('Use this token in the cron URL: /module/westernbid_starter_stripe/cron?token=YOUR_TOKEN'),
+                    ],
 
                 ],
                 'submit' => [

--- a/controllers/front/cron.php
+++ b/controllers/front/cron.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+
+class Westernbid_Starter_StripeCronModuleFrontController extends ModuleFrontController
+{
+    /**
+     * Disable header/footer rendering
+     *
+     * @var bool
+     */
+    public $display_header = false;
+    public $display_footer = false;
+
+    public function initContent()
+    {
+        parent::initContent();
+
+        header('Content-Type: application/json');
+
+        $token = Tools::getValue('token');
+        $expectedToken = Configuration::get(Westernbid_Starter_Stripe::STARTER_WB_STRIPE_CRON_TOKEN);
+
+        $tokensMatch = false;
+
+        if ($expectedToken && $token) {
+            $tokensMatch = function_exists('hash_equals')
+                ? hash_equals($expectedToken, (string) $token)
+                : $expectedToken === (string) $token;
+        }
+
+        if (!$tokensMatch) {
+            header('HTTP/1.1 403 Forbidden');
+            $this->ajaxDie(json_encode([
+                'status' => 'error',
+                'message' => 'Invalid token',
+            ]));
+        }
+
+        $result = $this->module->cancelExpiredOrders('cron', true);
+
+        $this->ajaxDie(json_encode($result));
+    }
+}

--- a/westernbid_starter_stripe.php
+++ b/westernbid_starter_stripe.php
@@ -33,6 +33,7 @@ class Westernbid_Starter_Stripe extends PaymentModule
     const STARTER_WB_STRIPE_SECRETKEY = 'PAYMENT_STARTER_WB_STRIPE_SECRETKEY';
     const STARTER_WB_STRIPE_BLOCK_DOWNLOADS = 'STARTER_WB_STRIPE_BLOCK_DOWNLOADS';
     const STARTER_WB_STRIPE_AUTO_CANCEL_HOURS = 'STARTER_WB_STRIPE_AUTO_CANCEL_HOURS';
+    const STARTER_WB_STRIPE_CRON_TOKEN = 'STARTER_WB_STRIPE_CRON_TOKEN';
 
     const MODULE_ADMIN_CONTROLLER = 'AdminConfigurePaymentWesternbidStripe';
     const STARTER_WB_STRIPE_WAITING_PAYMENT_STATE = 'STARTER_WB_STRIPE_WAITING_PAYMENT_STATE';
@@ -57,6 +58,7 @@ class Westernbid_Starter_Stripe extends PaymentModule
         $this->controllers = [
             'account',
             'cancel',
+            'cron',
             'external',
             'validation',
         ];
@@ -153,7 +155,8 @@ class Westernbid_Starter_Stripe extends PaymentModule
     {
         return (bool) Configuration::updateGlobalValue(static::STARTER_WB_STRIPE_ENABLED, '1')
             && (bool) Configuration::updateGlobalValue(static::STARTER_WB_STRIPE_BLOCK_DOWNLOADS, '1')
-            && (bool) Configuration::updateGlobalValue(static::STARTER_WB_STRIPE_AUTO_CANCEL_HOURS, '24');
+            && (bool) Configuration::updateGlobalValue(static::STARTER_WB_STRIPE_AUTO_CANCEL_HOURS, '24')
+            && (bool) Configuration::updateGlobalValue(static::STARTER_WB_STRIPE_CRON_TOKEN, Tools::passwdGen(32));
     }
 
     /**
@@ -165,7 +168,8 @@ class Westernbid_Starter_Stripe extends PaymentModule
     {
         return (bool) Configuration::deleteByName(static::STARTER_WB_STRIPE_ENABLED)
             && (bool) Configuration::deleteByName(static::STARTER_WB_STRIPE_BLOCK_DOWNLOADS)
-            && (bool) Configuration::deleteByName(static::STARTER_WB_STRIPE_AUTO_CANCEL_HOURS);
+            && (bool) Configuration::deleteByName(static::STARTER_WB_STRIPE_AUTO_CANCEL_HOURS)
+            && (bool) Configuration::deleteByName(static::STARTER_WB_STRIPE_CRON_TOKEN);
     }
 
     /**
@@ -336,16 +340,45 @@ class Westernbid_Starter_Stripe extends PaymentModule
             return;
         }
 
+        $this->cancelExpiredOrders('front_hook', false);
+    }
+
+    /**
+     * Cancel unpaid orders that were not paid within configured number of hours.
+     *
+     * @param string $contextName   Describes who triggered the cancellation (cron, hook, etc.)
+     * @param bool   $logWhenEmpty  Log message even if no orders were cancelled
+     *
+     * @return array
+     */
+    public function cancelExpiredOrders($contextName = 'manual', $logWhenEmpty = true)
+    {
         $autoCancelHours = (int) Configuration::get(static::STARTER_WB_STRIPE_AUTO_CANCEL_HOURS);
 
         if ($autoCancelHours <= 0) {
-            return;
+            if ($logWhenEmpty) {
+                PrestaShopLogger::addLog(sprintf('[WesternBid Stripe] Auto cancel skipped (%s): feature disabled', $contextName));
+            }
+
+            return [
+                'status' => 'skipped',
+                'cancelled' => 0,
+                'message' => 'Auto cancel disabled',
+            ];
         }
 
         $waitingState = (int) Configuration::get(static::STARTER_WB_STRIPE_WAITING_PAYMENT_STATE);
 
         if ($waitingState <= 0) {
-            return;
+            if ($logWhenEmpty) {
+                PrestaShopLogger::addLog(sprintf('[WesternBid Stripe] Auto cancel skipped (%s): waiting state missing', $contextName));
+            }
+
+            return [
+                'status' => 'skipped',
+                'cancelled' => 0,
+                'message' => 'Waiting order state missing',
+            ];
         }
 
         $deadline = date('Y-m-d H:i:s', time() - ($autoCancelHours * 3600));
@@ -360,10 +393,19 @@ class Westernbid_Starter_Stripe extends PaymentModule
         $orders = Db::getInstance()->executeS($query);
 
         if (empty($orders)) {
-            return;
+            if ($logWhenEmpty) {
+                PrestaShopLogger::addLog(sprintf('[WesternBid Stripe] Auto cancel processed (%s): no orders to cancel', $contextName));
+            }
+
+            return [
+                'status' => 'success',
+                'cancelled' => 0,
+                'message' => 'No orders to cancel',
+            ];
         }
 
         $cancelState = (int) Configuration::get('PS_OS_CANCELED');
+        $cancelledOrders = [];
 
         foreach ($orders as $orderData) {
             $orderId = (int) $orderData['id_order'];
@@ -382,6 +424,21 @@ class Westernbid_Starter_Stripe extends PaymentModule
             $orderHistory->id_order = $orderId;
             $orderHistory->changeIdOrderState($cancelState, $orderId);
             $orderHistory->addWithemail();
+
+            $cancelledOrders[] = $orderId;
         }
+
+        if (!empty($cancelledOrders)) {
+            PrestaShopLogger::addLog(sprintf('[WesternBid Stripe] Auto cancel processed (%s): cancelled orders %s', $contextName, implode(', ', $cancelledOrders)));
+        } elseif ($logWhenEmpty) {
+            PrestaShopLogger::addLog(sprintf('[WesternBid Stripe] Auto cancel processed (%s): no orders cancelled (possibly updated meanwhile)', $contextName));
+        }
+
+        return [
+            'status' => 'success',
+            'cancelled' => count($cancelledOrders),
+            'orders' => $cancelledOrders,
+            'message' => empty($cancelledOrders) ? 'No orders cancelled' : 'Orders cancelled',
+        ];
     }
 }


### PR DESCRIPTION
## Summary
- add secure cron front controller to trigger auto-cancellation of unpaid WesternBid orders
- refactor cancellation logic into reusable method with logging and configuration for cron token
- expose cron token in module settings and include cron controller in module routing

## Testing
- php -l westernbid_starter_stripe.php
- php -l controllers/front/cron.php
- php -l controllers/admin/AdminConfigurePaymentWesternbidStripeController.php

------
https://chatgpt.com/codex/tasks/task_b_68cbcd684c74832381e02123a26641ab