### PR TITLE
Add WesternBid logging utilities and admin viewer

### DIFF
--- a/controllers/admin/AdminConfigurePaymentWesternbidStripeController.php
+++ b/controllers/admin/AdminConfigurePaymentWesternbidStripeController.php
@@ -102,4 +102,69 @@ class AdminConfigurePaymentWesternbidStripeController extends ModuleAdminControl
             ],
         ];
     }
+
+    public function postProcess()
+    {
+        if (Tools::isSubmit('downloadWesternbidLog')) {
+            $this->processLogDownload();
+
+            return;
+        }
+
+        parent::postProcess();
+    }
+
+    public function initContent()
+    {
+        $this->initToolbar();
+        $this->initPageHeaderToolbar();
+
+        $this->content = $this->renderConfigurationAndLogs();
+
+        parent::initContent();
+    }
+
+    protected function renderConfigurationAndLogs()
+    {
+        $filters = [
+            'date_from' => Tools::getValue('wb_log_date_from'),
+            'date_to' => Tools::getValue('wb_log_date_to'),
+            'order_id' => Tools::getValue('wb_log_order_id'),
+        ];
+
+        $logEntries = $this->module->getLogEntries($filters, 200);
+
+        $this->context->smarty->assign([
+            'configuration_form' => parent::renderOptions(),
+            'log_entries' => $logEntries,
+            'log_filters' => $filters,
+            'log_file_exists' => '' !== $this->module->getLogFilePath() && is_readable($this->module->getLogFilePath()),
+            'log_download_action' => $this->context->link->getAdminLink(Westernbid_Starter_Stripe::MODULE_ADMIN_CONTROLLER),
+            'log_filter_action' => $this->context->link->getAdminLink(Westernbid_Starter_Stripe::MODULE_ADMIN_CONTROLLER),
+            'controller_name' => Westernbid_Starter_Stripe::MODULE_ADMIN_CONTROLLER,
+            'token' => Tools::getAdminTokenLite(Westernbid_Starter_Stripe::MODULE_ADMIN_CONTROLLER),
+        ]);
+
+        return $this->context->smarty->fetch('module:westernbid_starter_stripe/views/templates/admin/configure.tpl');
+    }
+
+    protected function processLogDownload()
+    {
+        $path = $this->module->getLogFilePath();
+
+        if ('' === $path || !is_readable($path)) {
+            $this->errors[] = $this->l('Log file is not available.');
+
+            return;
+        }
+
+        $filename = 'westernbid_logs_' . date('Ymd_His') . '.log';
+
+        header('Content-Type: text/plain');
+        header('Content-Disposition: attachment; filename="' . $filename . '"');
+        header('Content-Length: ' . filesize($path));
+
+        readfile($path);
+        exit;
+    }
 }

--- a/controllers/front/callback.php
+++ b/controllers/front/callback.php
@@ -38,9 +38,18 @@ class Westernbid_Starter_StripeCallbackModuleFrontController extends ModuleFront
 
         $wb_hash = md5($wb_login.$wb_result.$secret_key.$mc_gross.$invoice);
 
+        $id_order = (int) Tools::getValue('id_order');
+
+        $this->module->logEvent('callback_received', [
+            'order_id' => $id_order,
+            'invoice' => $invoice,
+            'payment_status' => isset($data['payment_status']) ? $data['payment_status'] : null,
+            'wb_result' => $wb_result,
+            'hash_valid' => hash_equals($wb_hash, isset($data['wb_hash']) ? $data['wb_hash'] : ''),
+        ]);
+
         if ($wb_hash == $data['wb_hash'])
         {
-            $id_order = (int) Tools::getValue('id_order');
             // Completed
             if ($data['payment_status'] == 'Completed')
             {
@@ -60,7 +69,19 @@ class Westernbid_Starter_StripeCallbackModuleFrontController extends ModuleFront
                         $this->module->sendPaymentAcceptedEmail($order);
                     }
                 }
+
+                $this->module->logEvent('payment_completed', [
+                    'order_id' => $id_order,
+                    'invoice' => $invoice,
+                    'amount' => $mc_gross,
+                ]);
             }
+        } else {
+            $this->module->logEvent('callback_rejected', [
+                'order_id' => $id_order,
+                'invoice' => $invoice,
+                'reason' => 'hash_mismatch',
+            ]);
         }
         die();
     }

--- a/controllers/front/cancel.php
+++ b/controllers/front/cancel.php
@@ -34,17 +34,30 @@ class Westernbid_Starter_StripeCancelModuleFrontController extends ModuleFrontCo
     {
         // @todo Use a transaction identifier instead, this is just an example
         $id_order = (int) Tools::getValue('id_order');
+        $reason = Tools::getValue('reason');
+
+        if ('' === trim($reason)) {
+            $reason = 'customer_cancel';
+        }
 
         // Order is already saved in PrestaShop
         if (false === empty($id_order)) {
             $order = new Order($id_order);
 
             if (false === Validate::isLoadedObject($order)) {
+                $this->module->logEvent('cancel_failed', [
+                    'order_id' => $id_order,
+                    'reason' => 'order_not_found',
+                ]);
                 // Order not found
                 Tools::redirect($this->context->link->getPageLink('index'));
             }
 
             if (false === $this->isRequestAuthorized($order)) {
+                $this->module->logEvent('cancel_failed', [
+                    'order_id' => $id_order,
+                    'reason' => 'unauthorized',
+                ]);
                 header('HTTP/1.1 403 Forbidden');
 
                 exit;
@@ -62,9 +75,19 @@ class Westernbid_Starter_StripeCancelModuleFrontController extends ModuleFrontCo
                 $this->module->sendOrderCancelledEmail($order);
             }
 
+            $this->module->logEvent('payment_cancelled', [
+                'order_id' => $id_order,
+                'reason' => $reason,
+            ]);
+
 
             Tools::redirect($this->context->link->getPageLink('index'));
         }
+
+        $this->module->logEvent('cancel_failed', [
+            'order_id' => null,
+            'reason' => 'missing_order_id',
+        ]);
 
         // Order not saved, redirect to Payment step
         Tools::redirect($this->context->link->getPageLink(

--- a/controllers/front/cron.php
+++ b/controllers/front/cron.php
@@ -47,6 +47,10 @@ class Westernbid_Starter_StripeCronModuleFrontController extends ModuleFrontCont
 
         if (!$tokensMatch) {
             header('HTTP/1.1 403 Forbidden');
+            $this->module->logEvent('auto_cancel_denied', [
+                'context' => 'cron',
+                'reason' => 'invalid_token',
+            ]);
             $this->ajaxDie(json_encode([
                 'status' => 'error',
                 'message' => 'Invalid token',
@@ -54,6 +58,11 @@ class Westernbid_Starter_StripeCronModuleFrontController extends ModuleFrontCont
         }
 
         $result = $this->module->cancelExpiredOrders('cron', true);
+
+        $this->module->logEvent('auto_cancel_summary', [
+            'context' => 'cron',
+            'result' => $result,
+        ]);
 
         $this->ajaxDie(json_encode($result));
     }

--- a/controllers/front/external.php
+++ b/controllers/front/external.php
@@ -128,6 +128,14 @@ class Westernbid_Starter_StripeExternalModuleFrontController extends ModuleFront
         $orderName = 'Order #' . $orderId;
         $invoice = $orderId;
 
+        $this->module->logEvent('order_created', [
+            'order_id' => (int) $orderId,
+            'cart_id' => (int) $this->context->cart->id,
+            'customer_id' => (int) $customer->id,
+            'amount' => Tools::ps_round($total, 2),
+            'currency' => $currency->iso_code,
+        ]);
+
 
         $wb_hash = md5($wb_login.$secret_key.$amount.$invoice);
 
@@ -165,6 +173,14 @@ class Westernbid_Starter_StripeExternalModuleFrontController extends ModuleFront
             'cancel_url' => $cancel_url,
             'return_url' => $success_url,
             'callback_url' => $callback_url,
+        ]);
+
+        $this->module->logEvent('redirect_to_westernbid', [
+            'order_id' => (int) $orderId,
+            'amount' => Tools::ps_round($amount, 2),
+            'currency' => $currency->iso_code,
+            'return_url' => $success_url,
+            'cancel_url' => $cancel_url,
         ]);
 
         $this->setTemplate('module:westernbid_starter_stripe/views/templates/front/external.tpl');

--- a/views/templates/admin/configure.tpl
+++ b/views/templates/admin/configure.tpl
@@ -1,0 +1,113 @@
+<div class="panel">
+  <div class="panel-heading">
+    {l s='WesternBid Stripe configuration' mod='westernbid_starter_stripe'}
+  </div>
+  <ul class="nav nav-tabs" role="tablist" id="wb-stripe-config-tabs">
+    <li class="active">
+      <a href="#wb-stripe-settings" role="tab" data-toggle="tab">
+        {l s='Settings' mod='westernbid_starter_stripe'}
+      </a>
+    </li>
+    <li>
+      <a href="#wb-stripe-logs" role="tab" data-toggle="tab">
+        {l s='WesternBid logs' mod='westernbid_starter_stripe'}
+      </a>
+    </li>
+  </ul>
+  <div class="tab-content">
+    <div class="tab-pane active" id="wb-stripe-settings">
+      {$configuration_form nofilter}
+    </div>
+    <div class="tab-pane" id="wb-stripe-logs">
+      <div class="panel">
+        <div class="panel-heading">
+          {l s='Log filters' mod='westernbid_starter_stripe'}
+        </div>
+        <div class="panel-body">
+          <form action="{$log_filter_action|escape:'htmlall':'UTF-8'}" method="get" class="form-horizontal">
+            <input type="hidden" name="controller" value="{$controller_name|escape:'htmlall':'UTF-8'}" />
+            <input type="hidden" name="token" value="{$token|escape:'htmlall':'UTF-8'}" />
+            <div class="form-group">
+              <label class="control-label col-lg-2" for="wb_log_date_from">{l s='Date from' mod='westernbid_starter_stripe'}</label>
+              <div class="col-lg-4">
+                <input type="date" id="wb_log_date_from" name="wb_log_date_from" class="form-control" value="{$log_filters.date_from|escape:'htmlall':'UTF-8'}" />
+              </div>
+              <label class="control-label col-lg-2" for="wb_log_date_to">{l s='Date to' mod='westernbid_starter_stripe'}</label>
+              <div class="col-lg-4">
+                <input type="date" id="wb_log_date_to" name="wb_log_date_to" class="form-control" value="{$log_filters.date_to|escape:'htmlall':'UTF-8'}" />
+              </div>
+            </div>
+            <div class="form-group">
+              <label class="control-label col-lg-2" for="wb_log_order_id">{l s='Order ID' mod='westernbid_starter_stripe'}</label>
+              <div class="col-lg-4">
+                <input type="text" id="wb_log_order_id" name="wb_log_order_id" class="form-control" value="{$log_filters.order_id|escape:'htmlall':'UTF-8'}" />
+              </div>
+            </div>
+            <div class="form-group">
+              <div class="col-lg-12">
+                <button type="submit" class="btn btn-primary">
+                  {l s='Apply filters' mod='westernbid_starter_stripe'}
+                </button>
+                <a href="{$log_filter_action|escape:'htmlall':'UTF-8'}" class="btn btn-default">
+                  {l s='Reset' mod='westernbid_starter_stripe'}
+                </a>
+              </div>
+            </div>
+          </form>
+          <form action="{$log_download_action|escape:'htmlall':'UTF-8'}" method="post" class="form-inline">
+            <input type="hidden" name="token" value="{$token|escape:'htmlall':'UTF-8'}" />
+            <button type="submit" name="downloadWesternbidLog" value="1" class="btn btn-default"{if !$log_file_exists} disabled="disabled"{/if}>
+              {l s='Download log' mod='westernbid_starter_stripe'}
+            </button>
+          </form>
+        </div>
+      </div>
+      <div class="panel">
+        <div class="panel-heading">
+          {l s='Recent log entries' mod='westernbid_starter_stripe'}
+        </div>
+        <div class="panel-body">
+          {if $log_entries|@count gt 0}
+            <table class="table table-striped">
+              <thead>
+                <tr>
+                  <th>{l s='Date' mod='westernbid_starter_stripe'}</th>
+                  <th>{l s='Event' mod='westernbid_starter_stripe'}</th>
+                  <th>{l s='Order' mod='westernbid_starter_stripe'}</th>
+                  <th>{l s='Details' mod='westernbid_starter_stripe'}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {foreach from=$log_entries item=entry}
+                  <tr>
+                    <td><span class="badge">{$entry.timestamp|escape:'htmlall':'UTF-8'}</span></td>
+                    <td>{$entry.event|escape:'htmlall':'UTF-8'}</td>
+                    <td>
+                      {if isset($entry.context.order_id) && $entry.context.order_id}
+                        {$entry.context.order_id|escape:'htmlall':'UTF-8'}
+                      {else}
+                        —
+                      {/if}
+                    </td>
+                    <td>
+                      <pre class="wb-log-context">{$entry.context_pretty|escape:'htmlall':'UTF-8'}</pre>
+                    </td>
+                  </tr>
+                {/foreach}
+              </tbody>
+            </table>
+          {else}
+            <div class="alert alert-info">
+              {l s='No log entries found for the selected filters.' mod='westernbid_starter_stripe'}
+            </div>
+          {/if}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<style>
+#wb-stripe-config-tabs { margin-bottom: 15px; }
+.wb-log-context { margin: 0; white-space: pre-wrap; word-break: break-word; }
+</style>

--- a/views/templates/admin/index.php
+++ b/views/templates/admin/index.php
@@ -1,0 +1,11 @@
+<?php
+/*
+ * 2007-2024 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * You should have received a copy of the Academic Free License 3.0
+ * along with this module. If not, see https://opensource.org/licenses/AFL-3.0
+ */
+
+die('Access denied.');

--- a/westernbid_starter_stripe.php
+++ b/westernbid_starter_stripe.php
@@ -50,6 +50,9 @@ class Westernbid_Starter_Stripe extends PaymentModule
         'actionValidateOrder',
     ];
 
+    const LOG_FILE_NAME = 'westernbid_starter_stripe.log';
+    const LOG_MAX_CONTEXT_LENGTH = 256;
+
     public function __construct()
     {
         $this->name = 'westernbid_starter_stripe';
@@ -131,6 +134,221 @@ class Westernbid_Starter_Stripe extends PaymentModule
 
 
         return $paymentOptions;
+    }
+
+    /**
+     * Log module-related event to file.
+     *
+     * @param string $event
+     * @param array $context
+     */
+    public function logEvent($event, array $context = [])
+    {
+        $path = $this->getLogFilePath();
+
+        if ('' === $path) {
+            return;
+        }
+
+        $sanitizedContext = $this->sanitizeLogContext($context);
+
+        $entry = [
+            'timestamp' => date(DATE_ATOM),
+            'event' => (string) $event,
+            'context' => $sanitizedContext,
+        ];
+
+        $encoded = json_encode($entry, JSON_UNESCAPED_UNICODE);
+
+        if (false === $encoded) {
+            return;
+        }
+
+        @file_put_contents($path, $encoded . PHP_EOL, FILE_APPEND | LOCK_EX);
+    }
+
+    /**
+     * @param array $filters
+     * @param int $limit
+     *
+     * @return array
+     */
+    public function getLogEntries(array $filters = [], $limit = 200)
+    {
+        $path = $this->getLogFilePath();
+
+        if ('' === $path || !is_readable($path)) {
+            return [];
+        }
+
+        $lines = @file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+
+        if (false === $lines) {
+            return [];
+        }
+
+        $dateFrom = null;
+        $dateTo = null;
+
+        if (!empty($filters['date_from'])) {
+            try {
+                $dateFrom = new DateTime($filters['date_from'] . ' 00:00:00');
+            } catch (Exception $e) {
+                $dateFrom = null;
+            }
+        }
+
+        if (!empty($filters['date_to'])) {
+            try {
+                $dateTo = new DateTime($filters['date_to'] . ' 23:59:59');
+            } catch (Exception $e) {
+                $dateTo = null;
+            }
+        }
+
+        $orderFilter = 0;
+
+        if (!empty($filters['order_id'])) {
+            $orderFilter = (int) $filters['order_id'];
+        }
+
+        $entries = [];
+
+        foreach (array_reverse($lines) as $line) {
+            $decoded = json_decode($line, true);
+
+            if (!is_array($decoded)) {
+                continue;
+            }
+
+            $timestamp = isset($decoded['timestamp']) ? $decoded['timestamp'] : '';
+
+            if ('' === $timestamp) {
+                continue;
+            }
+
+            try {
+                $entryDate = new DateTime($timestamp);
+            } catch (Exception $e) {
+                continue;
+            }
+
+            if (null !== $dateFrom && $entryDate < $dateFrom) {
+                continue;
+            }
+
+            if (null !== $dateTo && $entryDate > $dateTo) {
+                continue;
+            }
+
+            if ($orderFilter > 0) {
+                $orderId = 0;
+
+                if (isset($decoded['context']['order_id'])) {
+                    $orderId = (int) $decoded['context']['order_id'];
+                }
+
+                if ($orderId !== $orderFilter) {
+                    continue;
+                }
+            }
+
+            $contextData = isset($decoded['context']) && is_array($decoded['context']) ? $decoded['context'] : [];
+            $contextPretty = json_encode($contextData, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+
+            if (false === $contextPretty) {
+                $contextPretty = json_encode($this->sanitizeLogContext($contextData), JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+            }
+
+            if (false === $contextPretty) {
+                $contextPretty = '[]';
+            }
+
+            $entries[] = [
+                'timestamp' => $timestamp,
+                'event' => isset($decoded['event']) ? (string) $decoded['event'] : '',
+                'context' => $contextData,
+                'context_pretty' => $contextPretty,
+            ];
+
+            if ($limit > 0 && count($entries) >= (int) $limit) {
+                break;
+            }
+        }
+
+        return $entries;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLogFilePath()
+    {
+        if (!defined('_PS_ROOT_DIR_')) {
+            return '';
+        }
+
+        $logDir = _PS_ROOT_DIR_ . '/var/logs';
+
+        if (!is_dir($logDir)) {
+            @mkdir($logDir, 0775, true);
+        }
+
+        if (!is_dir($logDir) || !is_writable($logDir)) {
+            return '';
+        }
+
+        return $logDir . '/' . static::LOG_FILE_NAME;
+    }
+
+    /**
+     * @param array $context
+     *
+     * @return array
+     */
+    private function sanitizeLogContext(array $context)
+    {
+        $sensitiveKeys = [
+            'secret',
+            'secretkey',
+            'token',
+            'password',
+            'hash',
+            'signature',
+            'payload',
+            'wb_hash',
+            'secure_key',
+        ];
+
+        $sanitized = [];
+
+        foreach ($context as $key => $value) {
+            $normalizedKey = Tools::strtolower((string) $key);
+
+            if (in_array($normalizedKey, $sensitiveKeys)) {
+                $sanitized[$key] = '[hidden]';
+
+                continue;
+            }
+
+            if (is_array($value)) {
+                $sanitized[$key] = $this->sanitizeLogContext($value);
+
+                continue;
+            }
+
+            if (is_object($value)) {
+                $value = '[object ' . get_class($value) . ']';
+            }
+
+            if (is_string($value) && Tools::strlen($value) > static::LOG_MAX_CONTEXT_LENGTH) {
+                $value = Tools::substr($value, 0, static::LOG_MAX_CONTEXT_LENGTH) . '…';
+            }
+
+            $sanitized[$key] = $value;
+        }
+
+        return $sanitized;
     }
 
 
@@ -562,6 +780,11 @@ class Westernbid_Starter_Stripe extends PaymentModule
         if ($autoCancelHours <= 0) {
             if ($logWhenEmpty) {
                 PrestaShopLogger::addLog(sprintf('[WesternBid Stripe] Auto cancel skipped (%s): feature disabled', $contextName));
+                $this->logEvent('auto_cancel', [
+                    'status' => 'skipped',
+                    'context' => $contextName,
+                    'reason' => 'feature_disabled',
+                ]);
             }
 
             return [
@@ -576,6 +799,11 @@ class Westernbid_Starter_Stripe extends PaymentModule
         if ($waitingState <= 0) {
             if ($logWhenEmpty) {
                 PrestaShopLogger::addLog(sprintf('[WesternBid Stripe] Auto cancel skipped (%s): waiting state missing', $contextName));
+                $this->logEvent('auto_cancel', [
+                    'status' => 'skipped',
+                    'context' => $contextName,
+                    'reason' => 'waiting_state_missing',
+                ]);
             }
 
             return [
@@ -599,6 +827,12 @@ class Westernbid_Starter_Stripe extends PaymentModule
         if (empty($orders)) {
             if ($logWhenEmpty) {
                 PrestaShopLogger::addLog(sprintf('[WesternBid Stripe] Auto cancel processed (%s): no orders to cancel', $contextName));
+                $this->logEvent('auto_cancel', [
+                    'status' => 'success',
+                    'context' => $contextName,
+                    'cancelled' => 0,
+                    'message' => 'No orders to cancel',
+                ]);
             }
 
             return [
@@ -638,8 +872,20 @@ class Westernbid_Starter_Stripe extends PaymentModule
 
         if (!empty($cancelledOrders)) {
             PrestaShopLogger::addLog(sprintf('[WesternBid Stripe] Auto cancel processed (%s): cancelled orders %s', $contextName, implode(', ', $cancelledOrders)));
+            $this->logEvent('auto_cancel', [
+                'status' => 'success',
+                'context' => $contextName,
+                'cancelled' => count($cancelledOrders),
+                'orders' => $cancelledOrders,
+            ]);
         } elseif ($logWhenEmpty) {
             PrestaShopLogger::addLog(sprintf('[WesternBid Stripe] Auto cancel processed (%s): no orders cancelled (possibly updated meanwhile)', $contextName));
+            $this->logEvent('auto_cancel', [
+                'status' => 'success',
+                'context' => $contextName,
+                'cancelled' => 0,
+                'message' => 'No orders cancelled (possibly updated meanwhile)',
+            ]);
         }
 
         return [


### PR DESCRIPTION
## Summary
- add module log helper that writes sanitised JSON entries for WesternBid events
- log order lifecycle, callbacks, cancel actions and cron runs through the new helper
- expose a "WesternBid logs" admin tab with filters and log download support

## Testing
- php -l westernbid_starter_stripe.php
- php -l controllers/front/external.php
- php -l controllers/front/callback.php
- php -l controllers/front/cancel.php
- php -l controllers/front/cron.php
- php -l controllers/admin/AdminConfigurePaymentWesternbidStripeController.php

------
https://chatgpt.com/codex/tasks/task_b_68cbd4a487248323be45357fd891ea0c